### PR TITLE
Fix emoji autosuggest (make underscores work properly)

### DIFF
--- a/app/javascript/mastodon/emoji_index_light.js
+++ b/app/javascript/mastodon/emoji_index_light.js
@@ -49,7 +49,7 @@ function search(value, { emojisToShowFilter, maxResults, include, exclude, custo
       return [emojisList['-1']];
     }
 
-    let values = value.toLowerCase().split(/[\s|,|\-|_]+/);
+    let values = value.toLowerCase().split(/[\s|,|\-]+/);
 
     if (values.length > 2) {
       values = [values[0], values[1]];


### PR DESCRIPTION
Emoji autosuggest does not work properly when shortcode includes underscore.  That's because  underscores work as splitters in search function. 